### PR TITLE
dma-proxy: error-path fixes

### DIFF
--- a/linux-user-space-dma/Software/Kernel/dma-proxy.c
+++ b/linux-user-space-dma/Software/Kernel/dma-proxy.c
@@ -338,6 +338,7 @@ static int local_open(struct inode *ino, struct file *file)
  */
 static int release(struct inode *ino, struct file *file)
 {
+#if 0
 	struct dma_proxy_channel *pchannel_p = (struct dma_proxy_channel *)file->private_data;
 	struct dma_device *dma_device = pchannel_p->channel_p->device;
 
@@ -346,7 +347,6 @@ static int release(struct inode *ino, struct file *file)
 	 * This is not working and causes an issue that may need investigation in the 
 	 * DMA driver at the lower level.
 	 */
-#if 0
 	dma_device->device_terminate_all(pchannel_p->channel_p);
 #endif
 	return 0;
@@ -360,7 +360,6 @@ static int release(struct inode *ino, struct file *file)
 static long ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
 	struct dma_proxy_channel *pchannel_p = (struct dma_proxy_channel *)file->private_data;
-	dma_addr_t test;
 
 	/* Get the bd index from the input argument as all commands require it
 	 */

--- a/linux-user-space-dma/Software/Kernel/dma-proxy.c
+++ b/linux-user-space-dma/Software/Kernel/dma-proxy.c
@@ -364,7 +364,8 @@ static long ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 
 	/* Get the bd index from the input argument as all commands require it
 	 */
-	copy_from_user(&pchannel_p->bdindex, (int *)arg, sizeof(pchannel_p->bdindex)); 
+	if(copy_from_user(&pchannel_p->bdindex, (int *)arg, sizeof(pchannel_p->bdindex)))
+		return -EINVAL;
 
 	/* Perform the DMA transfer on the specified channel blocking til it completes
 	 */

--- a/linux-user-space-dma/Software/Kernel/dma-proxy.c
+++ b/linux-user-space-dma/Software/Kernel/dma-proxy.c
@@ -518,7 +518,7 @@ static int create_channel(struct platform_device *pdev, struct dma_proxy_channel
 		dmam_alloc_coherent(pchannel_p->dma_device_p,
 					sizeof(struct channel_buffer) * BUFFER_COUNT,
 					&pchannel_p->buffer_phys_addr, GFP_KERNEL);
-	printk(KERN_INFO "Allocating memory, virtual address: %016X physical address: %016X\n", 
+	printk(KERN_INFO "Allocating memory, virtual address: %px physical address: %px\n",
 			pchannel_p->buffer_table_p, (void *)pchannel_p->buffer_phys_addr);
 
 	/* Initialize each entry in the buffer descriptor table such that the physical address	

--- a/linux-user-space-dma/Software/Kernel/dma-proxy.c
+++ b/linux-user-space-dma/Software/Kernel/dma-proxy.c
@@ -494,12 +494,12 @@ static int create_channel(struct platform_device *pdev, struct dma_proxy_channel
 	/* Request the DMA channel from the DMA engine and then use the device from
 	 * the channel for the proxy channel also.
 	 */
+	pchannel_p->dma_device_p = &pdev->dev;
 	pchannel_p->channel_p = dma_request_slave_channel(&pdev->dev, name);
 	if (!pchannel_p->channel_p) {
 		dev_err(pchannel_p->dma_device_p, "DMA channel request error\n");
 		return ERROR;
 	}
-	pchannel_p->dma_device_p = &pdev->dev; 
 
 	/* Initialize the character device for the dma proxy channel
 	 */


### PR DESCRIPTION
This series of patches fixes 2 bugs in error-handling paths:
- Failure in dma_request_slave_channel produced a segfault rather than an error message, and
- Failure in copy_from_user in ioctl() proceeded with a bogus DMA instead of failing

There are also a few compiler-warning fixups.