### PR TITLE
replaced deprecated function call

### DIFF
--- a/linux-user-space-dma/Software/Kernel/dma-proxy.c
+++ b/linux-user-space-dma/Software/Kernel/dma-proxy.c
@@ -494,7 +494,7 @@ static int create_channel(struct platform_device *pdev, struct dma_proxy_channel
 	/* Request the DMA channel from the DMA engine and then use the device from
 	 * the channel for the proxy channel also.
 	 */
-	pchannel_p->channel_p = dma_request_slave_channel(&pdev->dev, name);
+	pchannel_p->channel_p = dma_request_chan(&pdev->dev, name);
 	if (!pchannel_p->channel_p) {
 		dev_err(pchannel_p->dma_device_p, "DMA channel request error\n");
 		return ERROR;


### PR DESCRIPTION
This patch works with kernel version 5.15.38 used in PetaLinux 2022.2, in which the "dma_request_slave_channel" function call is deprecated and renamed. Hence the newer "dma_request_chan" function is used.