### PR TITLE
dma-proxy: Add timeout, read and write file operations, improve printk() messages

### DIFF
--- a/linux-user-space-dma/Software/Common/dma-proxy.h
+++ b/linux-user-space-dma/Software/Common/dma-proxy.h
@@ -33,9 +33,11 @@
 #define FINISH_XFER 	_IOW('a','a',int32_t*)
 #define START_XFER 		_IOW('a','b',int32_t*)
 #define XFER 			_IOR('a','c',int32_t*)
+#define TIMEOUT_XFER	_IOW('a','d',int32_t*)
 
 struct channel_buffer {
 	unsigned int buffer[BUFFER_SIZE / sizeof(unsigned int)];
 	enum proxy_status { PROXY_NO_ERROR = 0, PROXY_BUSY = 1, PROXY_TIMEOUT = 2, PROXY_ERROR = 3 } status;
 	unsigned int length;
+	unsigned int residue;
 } __attribute__ ((aligned (1024)));		/* 64 byte alignment required for DMA, but 1024 handy for viewing memory */


### PR DESCRIPTION
- add configurable timeout via `ioctl()`
- add read and write file operations, able to test and use via [Linux's dd](https://man7.org/linux/man-pages/man1/dd.1.html)
- improve printing messages