### PR TITLE
Prevent potential buffer overflow in test size calculation

### DIFF
--- a/linux-user-space-dma/Software/User/dma-proxy-test.c
+++ b/linux-user-space-dma/Software/User/dma-proxy-test.c
@@ -350,9 +350,9 @@ int main(int argc, char *argv[])
 	 * convert it from KB to bytes
 	 */
 	test_size = atoi(argv[2]);
+	test_size *= 1024;
 	if (test_size > BUFFER_SIZE)
 		test_size = BUFFER_SIZE;
-	test_size *= 1024;
 
 	/* Verify is off by default to get pure performance of the DMA transfers without the CPU accessing all the data
 	 * to slow it down.


### PR DESCRIPTION
This pull request fixes a potential buffer overflow in the calculation of 'test_size', as described in issue [#4](https://github.com/Xilinx-Wiki-Projects/software-prototypes/issues/4). In the original code, 'test_size' (in KB) was compared to 'BUFFER_SIZE' (in bytes) before converting 'test_size' to bytes. This could lead to a buffer overflow.

The fix is simple: we now convert 'test_size' to bytes before comparing it to 'BUFFER_SIZE'. This ensures that 'test_size' never exceeds 'BUFFER_SIZE', preventing any potential buffer overflow. 